### PR TITLE
Only run helm tests in e2e

### DIFF
--- a/helm/node-exporter-app/templates/test/test-runner.yaml
+++ b/helm/node-exporter-app/templates/test/test-runner.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.e2e }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -38,3 +39,4 @@ spec:
   - name: tools
     emptyDir: {}
   restartPolicy: Never
+{{- end -}}

--- a/helm/node-exporter-app/templates/test/tests.yaml
+++ b/helm/node-exporter-app/templates/test/tests.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.e2e }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,3 +9,4 @@ data:
         curl --connect-timeout 10 --retry 12 --retry-delay 10 {{ .Values.name }}.{{ .Values.namespace }}:{{ .Values.port }}/metrics | \
         grep node_scrape.*success.*cpu.*1
     }
+{{- end -}}


### PR DESCRIPTION
Updates the chart so we only run the helm tests in e2e. Currently the configmap that holds the test logic is a leftover which makes kube-system untidy.

Existing test configmaps will be deleted by the migration logic in cluster-operator.