### PR TITLE
Updated circle config and remove priorityclass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,8 @@ workflows:
           app_catalog: "default-catalog"
           app_catalog_test: "default-test-catalog"
           chart: "node-exporter-app"
-          # Trigger job on git tag.
           filters:
+            # Trigger the job also on git tag.
             tags:
               only: /^v.*/
 
@@ -89,6 +89,7 @@ workflows:
             - build
             - push-to-default-app-catalog
           filters:
+            # Do not trigger the job on merge to master.
             branches:
               ignore:
                 - master

--- a/helm/node-exporter-app/templates/priorityclass.yaml
+++ b/helm/node-exporter-app/templates/priorityclass.yaml
@@ -1,8 +1,0 @@
-{{ if .Values.e2e }}
-apiVersion: scheduling.k8s.io/v1
-description: This priority class is used by giantswarm kubernetes components.
-kind: PriorityClass
-metadata:
-  name: giantswarm-critical
-value: 1000000000
-{{- end -}}

--- a/integration/templates/node_exporter_values.go
+++ b/integration/templates/node_exporter_values.go
@@ -1,6 +1,0 @@
-// +build k8srequired
-
-package templates
-
-// NodeExporterValues values used for kubernetes-node-exporter-chart in e2e integration test.
-const NodeExporterValues = `e2e: true`

--- a/integration/test/basic/main_test.go
+++ b/integration/test/basic/main_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/micrologger"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/giantswarm/node-exporter-app/integration/templates"
 )
 
 const (
@@ -100,7 +98,6 @@ func init() {
 
 			App: basicapp.Chart{
 				Name:            appName,
-				ChartValues:     templates.NodeExporterValues,
 				Namespace:       metav1.NamespaceSystem,
 				RunReleaseTests: true,
 				URL:             tarballURL,


### PR DESCRIPTION
Towards giantswarm/giantswarm#7675

The priorityclass is only needed for e2e and is now created by helmclient.