### PR TITLE
Major update to 1 0 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
-## Added
+### Added
 
 - Added workflows for automatic releases.
+
+### Updated
+
+- Updated node-exporter version to 1.0.1.
+
 
 ## [1.2.0] 2020-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Updated
 
 - Updated node-exporter version to 1.0.1.
-
+- Newly disabled collectors: powersupplyclass, schedstat, udp_queues.
 
 ## [1.2.0] 2020-01-08
 

--- a/helm/node-exporter-app/Chart.yaml
+++ b/helm/node-exporter-app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.18.1"
+appVersion: "v1.0.1"
 description: A Helm chart for Kubernetes Node-Exporter Service
 home: https://github.com/giantswarm/node-exporter-app
 name: node-exporter-app

--- a/helm/node-exporter-app/templates/daemonset.yaml
+++ b/helm/node-exporter-app/templates/daemonset.yaml
@@ -63,7 +63,10 @@ spec:
         - '--no-collector.diskstats'
         - '--no-collector.infiniband'
         - '--no-collector.ipvs'
+        - '--no-collector.powersupplyclass'
+        - '--no-collector.schedstat'
         - '--no-collector.textfile'
+        - '--no-collector.udp_queues'
         - '--no-collector.wifi'
         - '--no-collector.zfs'
         livenessProbe:

--- a/helm/node-exporter-app/values.yaml
+++ b/helm/node-exporter-app/values.yaml
@@ -13,7 +13,7 @@ groupID: 0
 image:
   registry: quay.io
   name: giantswarm/node-exporter
-  tag: v0.18.1-giantswarm
+  tag: v1.0.1-giantswarm
 
 resources:
   limits:


### PR DESCRIPTION
major node-exporter update to 1.10.1
Does not look like there is any breaking change that woudl affect us, changes are only in metrics we dont use atm: https://github.com/prometheus/node_exporter/releases/tag/v1.0.0

just disabled few new collectors we probabbly don't need