### PR TITLE
Do not set priorityClass in KVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not use priorityClass in KVM
+
 ## [1.4.0] - 2020-09-24
 
 ### Changed

--- a/helm/node-exporter-app/templates/daemonset.yaml
+++ b/helm/node-exporter-app/templates/daemonset.yaml
@@ -25,7 +25,13 @@ spec:
       securityContext:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.userGroup }}
+      {{- if .Values.Installation }}
+      {{- if ne .Values.Installation.V1.Provider.Kind "kvm" }}
       priorityClassName: system-node-critical
+      {{- end }}
+      {{- else }}
+      priorityClassName: system-node-critical
+      {{- end }}
       containers:
       - image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         name: {{ include "resource.default.name" . }}


### PR DESCRIPTION
Reason https://github.com/kubernetes/kubernetes/issues/60596
Towards https://github.com/giantswarm/giantswarm/issues/13332

For k8s `<1.17`, it fails with
```
Error creating: pods "node-exporter-app-unique-" is forbidden: pods with system-node-critical priorityClass is not permitted in monitoring namespace
```
This was not an issue in our test environment on KVM.
