### PR TITLE
Increase memory limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Disable `btrfs`,`softnet`,`rapl` and `thermal_zone` to reduce memory usage.
+- Increase memory limit to `75Mi`.
 
 ## [1.4.1] - 2020-09-24
 

--- a/helm/node-exporter-app/values.yaml
+++ b/helm/node-exporter-app/values.yaml
@@ -20,7 +20,7 @@ image:
 
 resources:
   limits:
-    memory: 50Mi
+    memory: 75Mi
   requests:
     cpu: 75m
     memory: 50Mi


### PR DESCRIPTION
We can still not keep below 50Mi on on-premise installations with many CPUs. It seems to be related to the new upstream version changes, but the increase seems small.

This might decrease the prio class even more, but we do not have a CPU limit already for this daemonset.