### PR TITLE
Enable the diskstats collector on azure installations only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+## Changed
+
+- Enable the diskstats collector on azure.
+
 ## [1.4.2] - 2020-09-30
 
 ### Changed

--- a/helm/node-exporter-app/templates/_resource.tpl
+++ b/helm/node-exporter-app/templates/_resource.tpl
@@ -23,3 +23,9 @@ room for such suffix.
 {{- include "resource.default.name" . -}}-pull-secret
 {{- end -}}
 
+{{- define "provider" -}}
+    {{- if .Values.Installation }}
+    {{- .Values.Installation.V1.Provider.Kind }}
+    {{- else -}}
+    {{- end -}}
+{{- end -}}

--- a/helm/node-exporter-app/templates/daemonset.yaml
+++ b/helm/node-exporter-app/templates/daemonset.yaml
@@ -67,7 +67,11 @@ spec:
         - '--collector.xfs'
 
         - '--no-collector.btrfs'
+        {{- if eq (include "provider" .) "azure" }}
+        - '--collector.diskstats'
+        {{- else }}
         - '--no-collector.diskstats'
+        {{- end }}
         - '--no-collector.infiniband'
         - '--no-collector.ipvs'
         - '--no-collector.powersupplyclass'

--- a/helm/node-exporter-app/templates/daemonset.yaml
+++ b/helm/node-exporter-app/templates/daemonset.yaml
@@ -47,6 +47,9 @@ spec:
         - '--collector.bcache'
         - '--collector.conntrack'
         - '--collector.cpu'
+        {{- if eq (include "provider" .) "azure" }}
+        - '--collector.diskstats'
+        {{- end }}
         - '--collector.edac'
         - '--collector.entropy'
         - '--collector.filefd'
@@ -67,9 +70,7 @@ spec:
         - '--collector.xfs'
 
         - '--no-collector.btrfs'
-        {{- if eq (include "provider" .) "azure" }}
-        - '--collector.diskstats'
-        {{- else }}
+        {{- if ne (include "provider" .) "azure" }}
         - '--no-collector.diskstats'
         {{- end }}
         - '--no-collector.infiniband'


### PR DESCRIPTION
Due to recent issues with disk IOPS, we would like to have more visibility on disk usage on azure installations.

This PR enables the `diskstats` collector on azure installations only.