### PR TITLE
Remove collectors

### DIFF
--- a/helm/node-exporter-app/templates/daemonset.yaml
+++ b/helm/node-exporter-app/templates/daemonset.yaml
@@ -54,9 +54,7 @@ spec:
         - '--collector.entropy'
         - '--collector.filefd'
         - '--collector.filesystem'
-        - '--collector.hwmon'
         - '--collector.loadavg'
-        - '--collector.mdadm'
         - '--collector.meminfo'
         - '--collector.netdev'
         - '--collector.netstat'
@@ -70,11 +68,16 @@ spec:
         - '--collector.xfs'
 
         - '--no-collector.btrfs'
+        - '--no-collector.bonding'
         {{- if ne (include "provider" .) "azure" }}
         - '--no-collector.diskstats'
         {{- end }}
+        - '--no-collector.hwmon'
         - '--no-collector.infiniband'
         - '--no-collector.ipvs'
+        - '--no-collector.mdadm'
+        - '--no-collector.nfs'
+        - '--no-collector.nfsd'
         - '--no-collector.powersupplyclass'
         - '--no-collector.rapl'
         - '--no-collector.schedstat'


### PR DESCRIPTION
There was a change in the behaviour of collectors in node_exporter [1.0.0](https://github.com/prometheus/node_exporter/releases/tag/v1.0.0) and they now return 0 for `node_scrape_collector_success` if no data is found.

We have a few collectors that were silently failing so far because they depend on files that do not exist (thus no collector data):
* bonding -> /sys/class/net/bonding_masters
* hwmon -> /sys/class/hwmon
* powersupplyclass -> /sys/class/power_supply
* nfs ->  /proc/net/rpc/nfs (or path.procfs/net/rpc/nfs)
* nfsd -> /proc/net/rpc/nfsd
* mdadm -> /proc/mdstat

This results in an avalanche of `NodeExporterCollectorFailed` alerts.
