### PR TITLE
Add options to be able to disable nvme and conntrack collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Add options to be able to disable `nvme` and `conntrack` collectors.
+
 ## [1.10.0] - 2022-03-02
 
 ### Changed

--- a/helm/node-exporter-app/templates/daemonset.yaml
+++ b/helm/node-exporter-app/templates/daemonset.yaml
@@ -49,7 +49,6 @@ spec:
 
         - '--collector.arp'
         - '--collector.bcache'
-        - '--collector.conntrack'
         - '--collector.cpu'
         - '--collector.edac'
         - '--collector.entropy'
@@ -85,6 +84,14 @@ spec:
         - '--no-collector.zfs'
         - '--no-collector.tapestats'
         - '--no-collector.fibrechannel'
+        {{- if .Values.disableConntrackCollector }}
+        - '--no-collector.conntrack'
+        {{- else }}
+        - '--collector.conntrack'
+        {{- end }}
+        {{- if .Values.disableNvmeCollector }}
+        - '--no-collector.nvme'
+        {{- end }}                
         livenessProbe:
           httpGet:
             path: /

--- a/helm/node-exporter-app/values.yaml
+++ b/helm/node-exporter-app/values.yaml
@@ -34,3 +34,6 @@ test:
 isManagementCluster: false
 registry:
   domain: docker.io
+
+disableConntrackCollector: false
+disableNvmeCollector: false


### PR DESCRIPTION
Because of the issues below, we need to disable `nvme` and `conntrack` collectors in some environments. This PR adds some options to do it in a backward-compatible way.

- https://github.com/prometheus/procfs/issues/407
- https://github.com/prometheus/node_exporter/pull/2089