### PR TITLE
Enabled `diskstats` collector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Enabled `diskstats` collector.
+
 ## [1.11.0] - 2022-04-07
 
-### Added
+### Added
 
 - Add options to be able to disable `nvme` and `conntrack` collectors.
 

--- a/helm/node-exporter-app/templates/daemonset.yaml
+++ b/helm/node-exporter-app/templates/daemonset.yaml
@@ -50,6 +50,7 @@ spec:
         - '--collector.arp'
         - '--collector.bcache'
         - '--collector.cpu'
+        - '--collector.diskstats'
         - '--collector.edac'
         - '--collector.entropy'
         - '--collector.filefd'
@@ -70,7 +71,6 @@ spec:
         - '--collector.xfs'
 
         - '--no-collector.btrfs'
-        - '--no-collector.diskstats'
         - '--no-collector.infiniband'
         - '--no-collector.ipvs'
         - '--no-collector.powersupplyclass'


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1093

enabled disk IO metrics