### PR TITLE
Disable boot partition from the `filesystem` exporter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable boot partition from the `filesystem` exporter.
+
 ## [1.12.0] - 2022-05-30
 
 ### Changed

--- a/helm/node-exporter-app/templates/daemonset.yaml
+++ b/helm/node-exporter-app/templates/daemonset.yaml
@@ -91,7 +91,9 @@ spec:
         {{- end }}
         {{- if .Values.disableNvmeCollector }}
         - '--no-collector.nvme'
-        {{- end }}                
+        {{- end }}
+
+        - '--collector.filesystem.mount-points-exclude=boot'
         livenessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22361

For some reason scraping of the boot partition fails on clusters without dockershim.
In any case boot partition does not need to be monitored for disk usage so it's safe to exclude it from scraping altogether.