### PR TITLE
Fix duplicate scrapping by Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix duplicated monitoring.
+
 ## [1.14.1] - 2022-12-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Fixed
 
-- Fix duplicated monitoring.
+- Fix duplicate scrapping by GiantSwarm Prometheus
 
 ## [1.14.1] - 2022-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Fixed
 
 - Fix collector `systemd`
+- Fix duplicate scrapping by GiantSwarm Prometheus
 
 ### Added
 
 - Add values schema
-
-### Fixed
-
-- Fix duplicate scrapping by GiantSwarm Prometheus
 
 ## [1.14.1] - 2022-12-22
 

--- a/helm/node-exporter-app/values.yaml
+++ b/helm/node-exporter-app/values.yaml
@@ -141,8 +141,8 @@ affinity: {}
 podAnnotations:
   # Fix for very slow GKE cluster upgrades
   cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-  # Fix duplicated monitoring.
-  # TBD: add reference to pmo scrape config
+  # Fix duplicate scrapping by Prometheus
+  # see: https://github.com/giantswarm/node-exporter-app/pull/171
   prometheus.io/scrape: "true"
   giantswarm.io/monitoring: "true"
 

--- a/helm/node-exporter-app/values.yaml
+++ b/helm/node-exporter-app/values.yaml
@@ -141,6 +141,10 @@ affinity: {}
 podAnnotations:
   # Fix for very slow GKE cluster upgrades
   cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+  # Fix duplicated monitoring.
+  # TBD: add reference to pmo scrape config
+  prometheus.io/scrape: "true"
+  giantswarm.io/monitoring: "true"
 
 # Extra labels to be added to node exporter pods
 podLabels: {}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/25216

This PR fixes an issue where node exporter was scrapped/monitored twice by Prometheus.

This is due to mutually exclusive jobs in Prometheus and the missing `giantswarm.io/monitoring` annotation on pod resources.

In more details Prometheus has 
- node-exporter job: old job we are moving away from
  it selects pods by name and namespace
  it ignores **pod** with the `giantswarm.io/monitoring` label or annotation; this condition exists so we can use the following job

- workload job: new job used for most things
  it selects endpoint which have the `giantswarm.io/monitoring` label or annotation on their **service**

In our case we have:
- node-exporter service with the `giantswarm.io/monitoring` annotation ([link](https://github.com/giantswarm/node-exporter-app/blob/301f0db16eb0a635c1e977ebacb388dad3e4e804/helm/node-exporter-app/values.yaml#L13-L22)) => this will be added into `workload` job
- pod missing the `giantswarm.io/monitoring` annotation => this will **also** be added into the `node-exporter` job

therefore we are scrapping node-exporter twice.

tl;dr adding the `giantswarm.io/monitoring` annotation to pods, make sure it is correctly ignored by the old `node-exporter` job in Prometheus
