### PR TITLE
- Disable PSPs for k8s 1.25 and newer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Update icon.
+- Disable PSPs for k8s 1.25 and newer.
 
 ## [1.15.0] - 2023-01-11
 

--- a/helm/node-exporter-app/templates/psp.yaml
+++ b/helm/node-exporter-app/templates/psp.yaml
@@ -1,4 +1,4 @@
-{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 {{- if .Values.rbac.create }}
 {{- if .Values.rbac.pspEnabled }}
 apiVersion: policy/v1beta1

--- a/helm/node-exporter-app/templates/psp.yaml
+++ b/helm/node-exporter-app/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if le (int .Capabilities.KubeVersion.Minor) 24 }}
 {{- if .Values.rbac.create }}
 {{- if .Values.rbac.pspEnabled }}
 apiVersion: policy/v1beta1
@@ -46,5 +47,6 @@ spec:
       - min: 0
         max: 65535
   readOnlyRootFilesystem: false
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
in k8s 1.25 there is no PodSecurityPolicy

this PR disables the PSP for 1.25