### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Disable PSPs for k8s 1.25 and newer.
+
 ## [1.15.1] - 2023-04-24
 
 ### Changed
 
 - Update icon.
-- Disable PSPs for k8s 1.25 and newer.
+
 
 ## [1.15.0] - 2023-01-11
 


### PR DESCRIPTION
I think automation did it wrong. According to the changelog, 1.15.1 includes my PSP changes, but if you check the tag it refers to the commit before my change.

this PR fixes the changelog so we can make a new release