### PR TITLE
allow config for serviceMonitor's namespace

### DIFF
--- a/helm/node-exporter-app/templates/servicemonitor.yaml
+++ b/helm/node-exporter-app/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ template "prometheus-node-exporter.monitor-namespace" . }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   {{- if .Values.prometheus.monitor.additionalLabels }}
     {{- toYaml .Values.prometheus.monitor.additionalLabels | nindent 4 }}

--- a/helm/node-exporter-app/values.yaml
+++ b/helm/node-exporter-app/values.yaml
@@ -23,6 +23,9 @@ env: {}
 ##  env:
 ##    VARIABLE: value
 
+serviceMonitor:
+  namespace: monitoring
+
 prometheus:
   monitor:
     enabled: true


### PR DESCRIPTION
To avoid `PrometheusRuleFailures` from paging because of missing relabellings.