### PR TITLE
revert changes on servicemonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- revert changes on servicemonitor
+
 ## [1.17.0] - 2023-08-01
 
 ### Added

--- a/helm/node-exporter-app/templates/servicemonitor.yaml
+++ b/helm/node-exporter-app/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}
-  namespace: {{ .Values.prometheus.monitor.namespace }}
+  namespace: {{ template "prometheus-node-exporter.monitor-namespace" . }}
   labels: {{ include "prometheus-node-exporter.labels" . | indent 4 }}
   {{- if .Values.prometheus.monitor.additionalLabels }}
     {{- toYaml .Values.prometheus.monitor.additionalLabels | nindent 4 }}

--- a/helm/node-exporter-app/values.yaml
+++ b/helm/node-exporter-app/values.yaml
@@ -44,39 +44,7 @@ prometheus:
     ##
     selectorOverride: {}
 
-    relabelings:
-    - action: replace
-      separator: ;
-      regex: ";(.*)"
-      replacement: $1
-      sourceLabels:
-      - namespace
-      - __meta_kubernetes_namespace
-      targetLabel: namespace
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_label_app_kubernetes_io_name
-      targetLabel: app
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_label_app_kubernetes_io_instance
-      targetLabel: instance
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_name
-      targetLabel: pod
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_container_name
-      targetLabel: container
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_node_name
-      targetLabel: node
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_node_label_role
-      targetLabel: role
+    relabelings: []
     metricRelabelings: []
     interval: ""
     scrapeTimeout: 10s


### PR DESCRIPTION
Reverting changes on servicemonitor since the upgrade of existing node-exporter is failing on clusters