### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [1.18.1] - 2023-10-23
 
 ### Changed
@@ -48,7 +52,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 ### Changed
 
 - Update icon.
-
 
 ## [1.15.0] - 2023-01-11
 

--- a/helm/node-exporter-app/values.yaml
+++ b/helm/node-exporter-app/values.yaml
@@ -50,38 +50,38 @@ prometheus:
     selectorOverride: {}
 
     relabelings:
-    - action: replace
-      separator: ;
-      regex: ";(.*)"
-      replacement: $1
-      sourceLabels:
-      - namespace
-      - __meta_kubernetes_namespace
-      targetLabel: namespace
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_label_app_kubernetes_io_name
-      targetLabel: app
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_label_app_kubernetes_io_instance
-      targetLabel: instance
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_name
-      targetLabel: pod
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_container_name
-      targetLabel: container
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_pod_node_name
-      targetLabel: node
-    - action: replace
-      sourceLabels:
-      - __meta_kubernetes_node_label_role
-      targetLabel: role
+      - action: replace
+        separator: ;
+        regex: ";(.*)"
+        replacement: $1
+        sourceLabels:
+          - namespace
+          - __meta_kubernetes_namespace
+        targetLabel: namespace
+      - action: replace
+        sourceLabels:
+          - __meta_kubernetes_pod_label_app_kubernetes_io_name
+        targetLabel: app
+      - action: replace
+        sourceLabels:
+          - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+        targetLabel: instance
+      - action: replace
+        sourceLabels:
+          - __meta_kubernetes_pod_name
+        targetLabel: pod
+      - action: replace
+        sourceLabels:
+          - __meta_kubernetes_pod_container_name
+        targetLabel: container
+      - action: replace
+        sourceLabels:
+          - __meta_kubernetes_pod_node_name
+        targetLabel: node
+      - action: replace
+        sourceLabels:
+          - __meta_kubernetes_node_label_role
+        targetLabel: role
     metricRelabelings: []
     interval: ""
     scrapeTimeout: 10s
@@ -317,7 +317,7 @@ readinessProbe:
   timeoutSeconds: 1
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 disableConntrackCollector: false
 disableNvmeCollector: false

--- a/helm/node-exporter-app/values.yaml
+++ b/helm/node-exporter-app/values.yaml
@@ -50,38 +50,38 @@ prometheus:
     selectorOverride: {}
 
     relabelings:
-      - action: replace
-        separator: ;
-        regex: ";(.*)"
-        replacement: $1
-        sourceLabels:
-          - namespace
-          - __meta_kubernetes_namespace
-        targetLabel: namespace
-      - action: replace
-        sourceLabels:
-          - __meta_kubernetes_pod_label_app_kubernetes_io_name
-        targetLabel: app
-      - action: replace
-        sourceLabels:
-          - __meta_kubernetes_pod_label_app_kubernetes_io_instance
-        targetLabel: instance
-      - action: replace
-        sourceLabels:
-          - __meta_kubernetes_pod_name
-        targetLabel: pod
-      - action: replace
-        sourceLabels:
-          - __meta_kubernetes_pod_container_name
-        targetLabel: container
-      - action: replace
-        sourceLabels:
-          - __meta_kubernetes_pod_node_name
-        targetLabel: node
-      - action: replace
-        sourceLabels:
-          - __meta_kubernetes_node_label_role
-        targetLabel: role
+    - action: replace
+      separator: ;
+      regex: ";(.*)"
+      replacement: $1
+      sourceLabels:
+      - namespace
+      - __meta_kubernetes_namespace
+      targetLabel: namespace
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_app_kubernetes_io_name
+      targetLabel: app
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_label_app_kubernetes_io_instance
+      targetLabel: instance
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_name
+      targetLabel: pod
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_container_name
+      targetLabel: container
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_pod_node_name
+      targetLabel: node
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_node_label_role
+      targetLabel: role
     metricRelabelings: []
     interval: ""
     scrapeTimeout: 10s


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
