### PR TITLE
Update Kyverno PolicyExceptions to v2beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update Kyverno `PolicyExceptions` to `v2beta1`.
+
 ## [1.20.0] - 2024-08-22
 
 ### Changed

--- a/helm/node-exporter-app/templates/pss-exceptions.yaml
+++ b/helm/node-exporter-app/templates/pss-exceptions.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.kyvernoPolicyExceptions.enabled }}
-{{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" }}
-apiVersion: kyverno.io/v2alpha1
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2beta1/PolicyException" }}
+apiVersion: kyverno.io/v2beta1
 kind: PolicyException
 metadata:
   name: {{ template "prometheus-node-exporter.fullname" . }}-exceptions


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30726

The current `v2alpha1` apiVersion is getting deprecated and removed in a future Kyverno version. 

`v2beta1` should be already available in all clusters.